### PR TITLE
Landing Page Signup Links

### DIFF
--- a/client/src/components/Pages/LandingPage/LandingPage.style.js
+++ b/client/src/components/Pages/LandingPage/LandingPage.style.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { ReactComponent as ArrowIcon } from "../../../assets/arrow.svg";
 import { size, colors } from "./../../../theme";
+import { Link } from "react-router-dom";
 
 export const Wrapper = styled.div`
   .ant-carousel .slick-slide {
@@ -145,7 +146,7 @@ export const CardDescription = styled.p`
   line-height: 30px;
 `;
 
-export const CardButton = styled.button`
+export const CardButton = styled(Link)`
   display: block;
   color: ${colors.white};
   background: ${colors.lightBlue};
@@ -163,6 +164,7 @@ export const CardButton = styled.button`
   transform: translateX(-50%);
   left: 50%;
   cursor: pointer;
+  to: ${props => props.to};
 `;
 
 export const FindMoreWrapper = styled.div`

--- a/client/src/components/Pages/LandingPage/index.js
+++ b/client/src/components/Pages/LandingPage/index.js
@@ -103,29 +103,29 @@ class LandingPage extends Component {
                   not create a custom one and let your interns start their
                   search for a host and mentor.
                 </CardDescription>
-                <CardButton>Find out more</CardButton>
+                <CardButton to="/sign-up/organisation">Get Started</CardButton>
               </FindMoreCard>
               <FindMoreCard>
                 <CardIcon src={hostFindMore} />
-                <CardTitle>Host</CardTitle>
+                <CardTitle>Intern</CardTitle>
                 <CardDescription>
                   Looking to learn more from industry professionals? If your
                   organisation is already a PressPad member, all you need to do
                   is ask to be invited. If they’re not, find out how you can
                   introduce them to PressPad.
                 </CardDescription>
-                <CardButton>Find out more</CardButton>
+                <CardButton to="/sign-up/intern">Get Started</CardButton>
               </FindMoreCard>
               <FindMoreCard>
                 <CardIcon src={internFindMore} />
-                <CardTitle>Intern</CardTitle>
+                <CardTitle>Host</CardTitle>
                 <CardDescription>
                   Want to be a mentor and a host? At the moment, our hosting
                   programme works on referral only basis, but we’ll soon start
                   receiving applications. Sign up to our newsletter and we’ll
                   let you know..
                 </CardDescription>
-                <CardButton>Find out more</CardButton>
+                <CardButton to="/sign-up/host/">Get Started</CardButton>
               </FindMoreCard>
             </FindMoreWrapper>
           </div>


### PR DESCRIPTION
#107 
Refactors "find out more" buttons in the landing page.
* The 3 buttons are now links instead.
* Links text now says `"Get Started"` instead of `"Find out more"`
* Links lead to each user type's respective signup form.
   * Organization: `/sign-up/organisation`
   * Intern: `/sign-up/intern`
   * Host: `/sign-up/host`
