### PR TITLE
Add "verified" badge only after successful hosting

### DIFF
--- a/client/src/components/Pages/HostProfile/index.js
+++ b/client/src/components/Pages/HostProfile/index.js
@@ -221,8 +221,8 @@ class HostProfile extends Component {
             }`}</Address>
           </HeadlineDiv>
           <SymbolDiv>
-            {/* this needs to be dynamically rendered at some point */}
-            <Symbol src={starSign} />
+            {/* this is the badge component */}
+            {this.state.profileData.profile.badge && <Symbol src={starSign} />}
           </SymbolDiv>
         </Header>
         <ImageSection>


### PR DESCRIPTION
#103 
Verified badge now only renders when first hosting is completed and the database key for badge is set to `true`

This is received in the component as `this.state.profileData.profile.badge`
